### PR TITLE
Couple of changes.

### DIFF
--- a/jazz-theme.el
+++ b/jazz-theme.el
@@ -104,7 +104,7 @@
    `(default ((,class (:foreground ,jazz-fg :background ,jazz-bg))))
    `(cursor ((,class (:foreground ,jazz-fg :background ,jazz-yellow))))
    `(escape-glyph-face ((,class (:foreground ,jazz-red))))
-   `(fringe ((,class (:foreground "#303030" :background ,jazz-bg))))
+   `(fringe ((,class (:foreground ,jazz-bg+2 :background ,jazz-bg+1))))
    `(header-line ((,class (:foreground ,jazz-yellow
                                        :background ,jazz-bg-1
                                        :box (:line-width -1 :color ,jazz-bg :style released-button)))))


### PR DESCRIPTION
Changed point color to be more visible, flyspell and flymake to use `:style wave` (available only for Emacs 24.3, but there is a check for older Emacsen) and added magit-item-highlight background color. Not sure about the wave style but at least it looks fancy. :smiley: 
