### PR TITLE
A bit lighter background for selected item in helm

### DIFF
--- a/jazz-theme.el
+++ b/jazz-theme.el
@@ -365,8 +365,8 @@
                            :background ,jazz-bg-1
                            :weight bold
                            :box (:line-width -1 :style released-button)))))
-   `(helm-selection ((,class (:background ,jazz-bg-1))))
-   `(helm-selection-line ((,class (:background ,jazz-bg-1))))
+   `(helm-selection ((,class (:background ,jazz-bg+1))))
+   `(helm-selection-line ((,class (:background ,jazz-bg+1))))
    `(helm-visible-mark ((,class (:foreground ,jazz-bg :background ,jazz-yellow-2))))
    `(helm-candidate-number ((,class (:foreground ,jazz-green+4 :background ,jazz-bg-1))))
 


### PR DESCRIPTION
Selected item in helm is barely visible by default (selected item is "monky-log"):
![jazz-helm](https://cloud.githubusercontent.com/assets/1516199/14420721/cd822f06-fff7-11e5-893b-91c76931ece6.png)

Using "jazz-bg+1" as background instead of "jazz-bg-1" makes it a bit better:
![jazz-helm-fixed](https://cloud.githubusercontent.com/assets/1516199/14420944/0f268992-fff9-11e5-8bfe-198dec433adc.png)

Making it a bit lighter would be better, but that unfortunately would not work for "helm-find-files" as it uses different foreground. Example using "jazz-bg+2":
![jazz-helm 2](https://cloud.githubusercontent.com/assets/1516199/14421169/4d96a76a-fffa-11e5-8996-0566ccde016a.png)
![jazz-helm 2-files](https://cloud.githubusercontent.com/assets/1516199/14421173/5085336a-fffa-11e5-8fe2-f7f95f5f354a.png)
