### PR TITLE
Use floating point values for markdown-mode header heights

### DIFF
--- a/jazz-theme.el
+++ b/jazz-theme.el
@@ -430,10 +430,10 @@
 
    ;; markdown
    `(markdown-header-face ((,class (:inherit variable-pitch))))
-   `(markdown-header-face-1 ((,class (:height 200 :inherit markdown-header-face))))
-   `(markdown-header-face-2 ((,class (:height 150 :inherit markdown-header-face))))
-   `(markdown-header-face-3 ((,class (:height 100 :inherit markdown-header-face))))
-   `(markdown-header-face-4 ((,class (:height 90  :inherit markdown-header-face))))
+   `(markdown-header-face-1 ((,class (:height 1.8 :inherit markdown-header-face))))
+   `(markdown-header-face-2 ((,class (:height 1.4 :inherit markdown-header-face))))
+   `(markdown-header-face-3 ((,class (:height 1.2 :inherit markdown-header-face))))
+   `(markdown-header-face-4 ((,class (:height 1.0 :inherit markdown-header-face))))
 
    ;; message-mode
    `(message-cited-text ((,class (:inherit font-lock-comment))))


### PR DESCRIPTION
This scales the faces rather than setting them to fixed integer heights.

See https://github.com/jrblevin/markdown-mode/issues/151 for details.